### PR TITLE
Add mention of Rodeo FX's OpenWalter project

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,7 @@ Projects and resources relating to Pixar's [Universal Scene Description](http://
 - Apple Finder and Preview application can display USD files natively
 - [AL_USDMaya](https://github.com/AnimalLogic/AL_USDMaya) Animal Logic's exporter maintains a live connection between the Maya and USD scenegraphs
 - [Arnold](https://github.com/LumaPictures/usd-arnold) Luma Pictures USD bridge for Arnold
+- [OpenWalter](https://github.com/rodeofx/OpenWalter) Rodeo FX's USD plugin suite for Arnold, Houdini, Katana and Maya.
 - [Houdini](https://graphics.pixar.com/usd/docs/Houdini-USD-Plugins.html)
 - [Katana](https://graphics.pixar.com/usd/docs/Katana-USD-Plugins.html)
 - [Model I/O](https://developer.apple.com/documentation/modelio) Apple's Model I/O brings USD to Metal


### PR DESCRIPTION
Hello!

I work at Rodeo FX. This past Siggraph our R&D team released an opensource USD project called "**[OpenWalter](https://github.com/rodeofx/OpenWalter)**" which encompasses a suite of USD plugins for Arnold, Katana, Houdini and Maya.

You can read more here: https://www.rodeofx.com/en/news/walter

It's currently focused around workflows doing rendering with Arnold, but other renderers could be added in the future. It is currently the way that we handle lookdev data at Rodeo FX and has been extensively used in production of various film projects.
