### PR TITLE
Add PyCharm plug-in to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -100,6 +100,7 @@ There are a variety of strategies for building USD.
 - [Syntax Highlighting](https://github.com/superfunc/usda-syntax) for vim, emacs & sublime.
 - [Sublime Syntax Highlighter](https://github.com/davidlatwe/PixarUSD-Sublime)
 - [Notepad++ Highlighter](https://github.com/Andrew/Hazelden/PIXAR-USD-Syntax-Highlighter)
+- [PyCharm Plug-in](https://github.com/justint/usd-idea)
 
 ## Resolvers
 


### PR DESCRIPTION
Hello! 

I've been working on a plug-in for PyCharm to provide support for USD files; syntax highlighting is one of the few features I've implemented along with a few more (structure/outline views, clickable reference links) that are in the works now.