### PR TITLE
Add ptc2usd and holopointer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,8 @@ Projects and resources relating to Pixar's [Universal Scene Description](http://
 - [gltf2usd](https://github.com/kcoley/gltf2usd) Convert gltf 2.0 files to USD
 - [animated cubes script](https://groups.google.com/forum/#!topic/usd-interest/dj9tUT8NcpI) Generate an animated file for testing
 - [USD Manager](http://www.usdmanager.org/) USD Manager by Dreamworks
+- [holopointer](https://github.com/simpassi/holopointer) Record from a Kinect USB device to USD (MacOS/Swift)
+- [ptc2usd](https://github.com/simpassi/ptc2usd) Pixar PTC and Houdini JSON point cloud to USD converter
 
 ## Integrations
 


### PR DESCRIPTION
holopointer is a MacOS Swift / Cocoa project for recording from a Kinect device directly to USD file sequences - along with a preview of the capture data and the 3D point cloud. It's useful for creating little recorded LIDAR-style visuals for VFX, animation and so on.

ptc2usd is a tool for people who have lots of point clouds from older RenderMan times - to bring them into the USD format. Also can read Houdini's JSON point cloud format on the side.